### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NorthstarDiscordRPC-${{ steps.extract.outputs.commit }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
         run: |
           cargo build --release --verbose
       - name: Upload RPC build as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: northstar-discord-rpc
           path: |
             target/release/*.dll
       - name: Upload debug build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: discord-rpc-debug-files
           path: |


### PR DESCRIPTION
v3 uses an older Node version that will soon no longer be supported by GitHub Actions