### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download compiled RPC
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: northstar-discord-rpc
           path: northstar-discord-rpc
       - name: Download debug files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: discord-rpc-debug-files
           path: discord-rpc-debug-files


### PR DESCRIPTION
v3 uses an older Node version that will soon no longer be supported by GitHub Actions