### PR TITLE
Bump microsoft/setup-msbuild to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build
         run: |
           cargo build --release --verbose


### PR DESCRIPTION
v1 uses an older Node version that will soon no longer be supported by GitHub Actions