### PR TITLE
Semi-fix singleplayer presence

### DIFF
--- a/src/presence.rs
+++ b/src/presence.rs
@@ -152,8 +152,9 @@ fn on_presence_updated(
             activity.large_text = Some(map_displayname);
             activity.small_image = Some("northstar".to_string());
             activity.small_text = Some("Titanfall 2 + Northstar".to_string());
-            if cl_presence.playlist == "campaign" {
+            if cl_presence.playlist == "solo" {
                 activity.party = None;
+                activity.state = "Playing Singleplayer".to_string();
                 activity.end = None;
             } else if cl_presence.playlist == "fd" {
                 cl_presence


### PR DESCRIPTION
Right now rich presence doesn't work in singleplayer, because the discord app the plugin uses doesn't have images for any of its levels, causing an error and preventing the plugin from working after that. 

<img width="953" height="60" alt="Screenshot 2025-09-26 09_57_13" src="https://github.com/user-attachments/assets/96c0f0da-3e9e-4162-929e-1ec69e0abcf1" />

BUT, if that issue was fixed, it would still have 3 other ones:

1. Gamemode information doesn't get disabled because the plugin isn't checking for the right playlist
2. The level's name doesn't show up properly due to the way their localization gets searched for (this will get fixed later in a mods pr)
3. The level's name shows up twice

This fixes the first and third issues, so if someone adds the missing images for singleplayer, we'll have proper rich presence for the campaign. Now it cheks for the right playlist (solo) and replaces the second campaign level name with a "Playing Singleplayer" text.

Before (With image):
<img width="350" height="141" alt="Screenshot 2025-09-26 10_24_04" src="https://github.com/user-attachments/assets/e051bbb4-085e-4f6c-9b56-dbb76e352f2c" />

After:
<img width="356" height="153" alt="Screenshot 2025-09-26 11_03_56" src="https://github.com/user-attachments/assets/b4f1599e-c368-49f3-99ea-2c1035ecef90" />

(Ignore the Vanilla+ text. I first tested these changes on my own fork intented for Vanilla+)